### PR TITLE
Add Getters for NPC's Item, Text, and State

### DIFF
--- a/api/src/main/java/net/jitse/npclib/api/NPC.java
+++ b/api/src/main/java/net/jitse/npclib/api/NPC.java
@@ -112,4 +112,19 @@ public interface NPC {
     NPC setItem(NPCSlot slot, ItemStack item);
 
     NPC setText(List<String> text);
+    
+    /**
+     * Get the text of an NPC
+     *
+     * @return List<String> text
+     */
+    List<String> getText();
+    
+    /**
+     * Get a NPC's item.
+     *
+     * @param slot The slot the item is in.
+     * @return ItemStack item.
+     */
+    ItemStack getItem(NPCSlot slot);
 }

--- a/api/src/main/java/net/jitse/npclib/api/NPC.java
+++ b/api/src/main/java/net/jitse/npclib/api/NPC.java
@@ -101,6 +101,14 @@ public interface NPC {
      * @return Object instance.
      */
     NPC toggleState(NPCState state);
+    
+    /**
+     * Get state of NPC.
+     *
+     * @param state The state requested.
+     * @return boolean on/off status.
+     */
+    boolean getState(NPCState state);
 
     /**
      * Change the item in the inventory of the NPC.

--- a/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
@@ -221,6 +221,18 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
     }
 
     @Override
+    public boolean getState(NPCState state) {
+        if (activeStates.length != 0) {
+            for (int i = 0; i < activeStates.length; i++) {
+                if (activeStates[i] == state) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    @Override
     public NPC toggleState(NPCState state) {
         int inActiveStatesIndex = -1;
         if (activeStates.length == 0) { // If there're no active states, this is the first to be toggled (on).

--- a/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
+++ b/api/src/main/java/net/jitse/npclib/internal/NPCBase.java
@@ -264,6 +264,29 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
     }
 
     @Override
+    public ItemStack getItem(NPCSlot slot) {
+        if (slot == null) {
+            throw new NullPointerException("Slot cannot be null");
+        }
+        switch (slot) {
+            case HELMET:
+                return this.helmet;
+            case CHESTPLATE:
+                return this.chestplate;
+            case LEGGINGS:
+                return this.leggings;
+            case BOOTS:
+                return this.boots;
+            case MAINHAND:
+                return this.inHand;
+            case OFFHAND:
+                return this.offHand;
+            default:
+                throw new IllegalArgumentException("Entered an invalid inventory slot");
+        }
+    }
+    
+    @Override
     public NPC setItem(NPCSlot slot, ItemStack item) {
         if (slot == null) {
             throw new NullPointerException("Slot cannot be null");
@@ -314,5 +337,10 @@ public abstract class NPCBase implements NPC, NPCPacketHandler {
 
         this.text = text;
         return this;
+    }
+    
+    @Override
+    public List<String> getText() {
+        return text;
     }
 }


### PR DESCRIPTION
I have some new features for handling NPC properties. Currently there are a few methods for an NPC's properties, but they are limited to varying degrees.

It would be nice to have methods to retrieve an NPC's item, text, and state. There are setters, but there are no corresponding getters for these methods:
- NPC#setItem(NPCSlot, ItemStack)
- NPC#setText(List<String>)
- NPC#toggleState(NPCState)

So, I'm submitting a PR for a few simple methods to return these values, since they're already present in NPCBase