### PR TITLE
Update ChunkListener to fix a minor NPE bug

### DIFF
--- a/api/src/main/java/net/jitse/npclib/listeners/ChunkListener.java
+++ b/api/src/main/java/net/jitse/npclib/listeners/ChunkListener.java
@@ -45,8 +45,12 @@ public class ChunkListener implements Listener {
                 if (npc.getAutoHidden().contains(uuid)) {
                     continue;
                 }
-
-                npc.hide(Bukkit.getPlayer(uuid), true);
+                
+                // Bukkit.getPlayer(uuid) sometimes returns null
+                Player player = Bukkit.getPlayer(uuid);
+                if (player != null) {
+                    npc.hide(player, true);
+                }
             }
         }
     }


### PR DESCRIPTION
I've been getting an NPE caused by a null value being passed from ChunkListener.java:
https://pastebin.com/YchixMYE

It's no big deal, so I figured I would submit a PR. This will fix the NullPointerException at the root of the problem. Bukkit.getPlayer(UUID) can return a null value, so a simple null check will do the trick.