### PR TITLE
Implement proper multi-threading

### DIFF
--- a/api/src/main/java/net/jitse/npclib/api/skin/MineSkinFetcher.java
+++ b/api/src/main/java/net/jitse/npclib/api/skin/MineSkinFetcher.java
@@ -20,7 +20,7 @@ import java.util.Scanner;
 public class MineSkinFetcher {
 
     private static final String MINESKIN_API = "https://api.mineskin.org/get/id/";
-    private static final ExecutorService threadPool = Executors.newCachedThreadPool();
+    private static final ExecutorService threadPool = Executors.newSingleThreadExecutor();
 
     public static void fetchSkinFromIdAsync(int id, Callback callback) {
         threadPool.execute(() -> {

--- a/api/src/main/java/net/jitse/npclib/api/skin/MineSkinFetcher.java
+++ b/api/src/main/java/net/jitse/npclib/api/skin/MineSkinFetcher.java
@@ -20,9 +20,10 @@ import java.util.Scanner;
 public class MineSkinFetcher {
 
     private static final String MINESKIN_API = "https://api.mineskin.org/get/id/";
+    private static final ExecutorService threadPool = Executors.newCachedThreadPool();
 
     public static void fetchSkinFromIdAsync(int id, Callback callback) {
-        new Thread(() -> {
+        threadPool.execute(() -> {
             try {
                 StringBuilder builder = new StringBuilder();
                 HttpURLConnection httpURLConnection = (HttpURLConnection) new URL(MINESKIN_API + id).openConnection();
@@ -50,7 +51,7 @@ public class MineSkinFetcher {
                 exception.printStackTrace();
                 callback.failed();
             }
-        }).start();
+        });
     }
 
     public interface Callback {


### PR DESCRIPTION
Use a thread pool rather than direct thread creation. Thread pools are preferable because they avoid the costly instantiation that raw Thread operations incur. The pool is static because MineSkinFetcher is also static.

I would use Bukkit's scheduler for asynchronous operations, but it requires a non-null JavaPlugin and MineSkinFetcher can't get a JavaPlugin.

I initially used a cached thread pool. However, I personally create my NPCs and load their skins on startup, and I imagine others, also, don't view skin loading as a highly critical, time-sensitive task. So, I realised that there wouldn't be any advantage of a cached thread pool. If anything, it makes *more* sense to use *less* resources at startup, since resources are scarce at startup when everything is loading. For NPCLib, a single thread pool works best, in order to consume less system resources.