### PR TITLE
Add 1.15 support and cleanup some code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ install:
   - ls $HOME/.m2/repository/org/spigotmc/spigot/1.13-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.13 >> /dev/null 2>&1
   - ls $HOME/.m2/repository/org/spigotmc/spigot/1.13.2-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.13.2 >> /dev/null 2>&1
   - ls $HOME/.m2/repository/org/spigotmc/spigot/1.14.4-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.14.4 >> /dev/null 2>&1
+  - ls $HOME/.m2/repository/org/spigotmc/spigot/1.15.2-R0.1-SNAPSHOT >> /dev/null 2>&1 || java -jar BuildTools.jar --rev 1.15.2 >> /dev/null 2>&1
 script:
   - mvn clean install

--- a/api/src/main/java/net/jitse/npclib/NPCLib.java
+++ b/api/src/main/java/net/jitse/npclib/NPCLib.java
@@ -39,8 +39,7 @@ public final class NPCLib {
         this.npcClass = npcClass;
 
         if (npcClass == null) {
-            logger.severe("Failed to initiate. Your server's version ("
-                    + versionName + ") is not supported");
+            logger.severe("Failed to initiate. Your server's version (" + versionName + ") is not supported");
             return;
         }
 
@@ -96,7 +95,7 @@ public final class NPCLib {
         try {
             return (NPC) npcClass.getConstructors()[0].newInstance(this, text);
         } catch (Exception exception) {
-            logger.warning("Failed to create NPC. Please report the following stacktrace message: " + exception.getMessage());
+            logger.warning("Failed to create NPC. Please report the following stacktrace message", exception);
         }
 
         return null;

--- a/api/src/main/java/net/jitse/npclib/api/events/NPCHideEvent.java
+++ b/api/src/main/java/net/jitse/npclib/api/events/NPCHideEvent.java
@@ -54,6 +54,7 @@ public class NPCHideEvent extends Event implements Cancellable {
         return cancelled;
     }
 
+    @Override
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/api/src/main/java/net/jitse/npclib/api/events/NPCInteractEvent.java
+++ b/api/src/main/java/net/jitse/npclib/api/events/NPCInteractEvent.java
@@ -38,6 +38,7 @@ public class NPCInteractEvent extends Event {
         return this.npc;
     }
 
+    @Override
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/api/src/main/java/net/jitse/npclib/api/events/NPCShowEvent.java
+++ b/api/src/main/java/net/jitse/npclib/api/events/NPCShowEvent.java
@@ -54,6 +54,7 @@ public class NPCShowEvent extends Event implements Cancellable {
         return cancelled;
     }
 
+    @Override
     public HandlerList getHandlers() {
         return handlers;
     }

--- a/api/src/main/java/net/jitse/npclib/api/skin/MineSkinFetcher.java
+++ b/api/src/main/java/net/jitse/npclib/api/skin/MineSkinFetcher.java
@@ -7,12 +7,13 @@ package net.jitse.npclib.api.skin;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * @author Jitse Boonstra
@@ -20,10 +21,10 @@ import java.util.Scanner;
 public class MineSkinFetcher {
 
     private static final String MINESKIN_API = "https://api.mineskin.org/get/id/";
-    private static final ExecutorService threadPool = Executors.newSingleThreadExecutor();
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
 
     public static void fetchSkinFromIdAsync(int id, Callback callback) {
-        threadPool.execute(() -> {
+        EXECUTOR.execute(() -> {
             try {
                 StringBuilder builder = new StringBuilder();
                 HttpURLConnection httpURLConnection = (HttpURLConnection) new URL(MINESKIN_API + id).openConnection();
@@ -47,7 +48,7 @@ public class MineSkinFetcher {
 
                 callback.call(new Skin(value, signature));
             } catch (IOException exception) {
-                Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "Could not fetch skin! (Id: " + id + "). Message: " + exception.getMessage());
+                Bukkit.getLogger().severe("Could not fetch skin! (Id: " + id + "). Message: " + exception.getMessage());
                 exception.printStackTrace();
                 callback.failed();
             }

--- a/api/src/main/java/net/jitse/npclib/api/state/NPCSlot.java
+++ b/api/src/main/java/net/jitse/npclib/api/state/NPCSlot.java
@@ -2,20 +2,30 @@ package net.jitse.npclib.api.state;
 
 public enum NPCSlot {
 
-    HELMET(4),
-    CHESTPLATE(3),
-    LEGGINGS(2),
-    BOOTS(1),
-    MAINHAND(0),
-    OFFHAND(5);
+    HELMET(4, "HEAD"),
+    CHESTPLATE(3, "CHEST"),
+    LEGGINGS(2, "LEGS"),
+    BOOTS(1, "FEET"),
+    MAINHAND(0, "MAINHAND"),
+    OFFHAND(5, "OFFHAND");
 
-    int slot;
+    private final int slot;
+    private final String nmsName;
 
-    NPCSlot(int slot) {
+    NPCSlot(int slot, String nmsName) {
         this.slot = slot;
+        this.nmsName = nmsName;
     }
 
     public int getSlot() {
         return slot;
+    }
+
+    public String getNmsName() {
+        return nmsName;
+    }
+
+    public <E extends Enum<E>> E getNmsEnum(Class<E> nmsEnumClass) {
+        return Enum.valueOf(nmsEnumClass, this.nmsName);
     }
 }

--- a/api/src/main/java/net/jitse/npclib/api/state/NPCState.java
+++ b/api/src/main/java/net/jitse/npclib/api/state/NPCState.java
@@ -1,12 +1,14 @@
 package net.jitse.npclib.api.state;
 
+import java.util.Collection;
+
 public enum NPCState {
 
     ON_FIRE((byte) 1),
     CROUCHED((byte) 2),
     INVISIBLE((byte) 32);
 
-    private byte b;
+    private final byte b;
 
     NPCState(byte b) {
         this.b = b;
@@ -16,10 +18,15 @@ public enum NPCState {
         return b;
     }
 
-    public static byte getMasked(final NPCState... status) {
-        byte b = 0;
-        for (NPCState s : status) b |= s.getByte();
-        return b;
+    public static byte getMasked(NPCState... states) {
+        byte mask = 0;
+        for (NPCState state : states) mask |= state.getByte();
+        return mask;
+    }
+
+    public static byte getMasked(Collection<NPCState> states) {
+        byte mask = 0;
+        for (NPCState state : states) mask |= state.getByte();
+        return mask;
     }
 }
-

--- a/api/src/main/java/net/jitse/npclib/api/utilities/Logger.java
+++ b/api/src/main/java/net/jitse/npclib/api/utilities/Logger.java
@@ -6,6 +6,8 @@ package net.jitse.npclib.api.utilities;
 
 import org.bukkit.Bukkit;
 
+import java.util.logging.Level;
+
 public class Logger {
 
     private final String prefix;
@@ -21,26 +23,34 @@ public class Logger {
     }
 
     public void info(String info) {
-        if (!enabled) {
-            return;
-        }
-
-        Bukkit.getLogger().info(prefix + info);
+        log(Level.INFO, info);
     }
 
     public void warning(String warning) {
-        if (!enabled) {
-            return;
-        }
+        log(Level.WARNING, warning);
+    }
 
-        Bukkit.getLogger().warning(prefix + warning);
+    public void warning(String warning, Throwable throwable) {
+        log(Level.WARNING, warning, throwable);
     }
 
     public void severe(String severe) {
-        if (!enabled) {
-            return;
-        }
+        log(Level.SEVERE, severe);
+    }
 
-        Bukkit.getLogger().severe(prefix + severe);
+    public void severe(String severe, Throwable throwable) {
+        log(Level.SEVERE, severe, throwable);
+    }
+
+    public void log(Level level, String message) {
+        if (enabled) {
+            Bukkit.getLogger().log(level, prefix + message);
+        }
+    }
+
+    public void log(Level level, String message, Throwable throwable) {
+        if (enabled) {
+            Bukkit.getLogger().log(level, prefix + message, throwable);
+        }
     }
 }

--- a/api/src/main/java/net/jitse/npclib/hologram/Hologram.java
+++ b/api/src/main/java/net/jitse/npclib/hologram/Hologram.java
@@ -51,7 +51,7 @@ public class Hologram {
             .getConstructor(PACKET_PLAY_OUT_ENTITY_METADATA_CLAZZ, int.class, DATAWATCHER_CLAZZ, boolean.class);
 
     // Fields:
-    private static final Reflection.FieldAccessor playerConnectionField = Reflection.getField(ENTITY_PLAYER_CLAZZ,
+    private static final Reflection.FieldAccessor<?> playerConnectionField = Reflection.getField(ENTITY_PLAYER_CLAZZ,
             "playerConnection", PLAYER_CONNECTION_CLAZZ);
 
     // Methods:
@@ -92,8 +92,7 @@ public class Hologram {
     }
 
     private void createPackets() {
-        // TODO: Check when this method was changed (1.9 R2 is giving an exception...)
-        Reflection.MethodInvoker gravityMethod = (version.isAboveOrEqual(MinecraftVersion.V1_9_R2) ?
+        Reflection.MethodInvoker gravityMethod = (version.isAboveOrEqual(MinecraftVersion.V1_10_R1) ?
                 Reflection.getMethod(ENTITY_CLAZZ, "setNoGravity", boolean.class) :
                 Reflection.getMethod(ENTITY_ARMOR_STAND_CLAZZ, "setGravity", boolean.class));
 
@@ -213,4 +212,3 @@ public class Hologram {
         }
     }
 }
-

--- a/api/src/main/java/net/jitse/npclib/internal/MinecraftVersion.java
+++ b/api/src/main/java/net/jitse/npclib/internal/MinecraftVersion.java
@@ -6,8 +6,17 @@ package net.jitse.npclib.internal;
 
 public enum MinecraftVersion {
 
-    V1_8_R1, V1_8_R2, V1_8_R3, V1_9_R1, V1_9_R2, V1_10_R1, V1_11_R1, V1_12_R1, V1_13_R1, V1_13_R2, V1_14_R1;
-
+    V1_8_R2,
+    V1_8_R3,
+    V1_9_R1,
+    V1_9_R2,
+    V1_10_R1,
+    V1_11_R1,
+    V1_12_R1,
+    V1_13_R1,
+    V1_13_R2,
+    V1_14_R1,
+    V1_15_R1;
 
     public boolean isAboveOrEqual(MinecraftVersion compare) {
         return ordinal() >= compare.ordinal();

--- a/api/src/main/java/net/jitse/npclib/listeners/ChunkListener.java
+++ b/api/src/main/java/net/jitse/npclib/listeners/ChunkListener.java
@@ -60,7 +60,7 @@ public class ChunkListener implements Listener {
         Chunk chunk = event.getChunk();
 
         for (NPCBase npc : NPCManager.getAllNPCs()) {
-            if (!isSameChunk(npc.getLocation(), chunk))
+            if (npc.getLocation() == null || !isSameChunk(npc.getLocation(), chunk))
                 continue; // The NPC is not in the loaded chunk.
 
             // The chunk being loaded has this NPC in it. Showing it to all the players again.
@@ -89,7 +89,6 @@ public class ChunkListener implements Listener {
             }
         }
     }
-
 
     private static int getChunkCoordinate(int coordinate) {
         return coordinate >> 4;

--- a/api/src/main/java/net/jitse/npclib/listeners/PacketListener.java
+++ b/api/src/main/java/net/jitse/npclib/listeners/PacketListener.java
@@ -16,7 +16,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -29,8 +28,8 @@ public class PacketListener {
     private final Class<?> packetPlayInUseEntityClazz = Reflection.getMinecraftClass("PacketPlayInUseEntity");
 
     // Fields:
-    private final Reflection.FieldAccessor entityIdField = Reflection.getField(packetPlayInUseEntityClazz, "a", int.class);
-    private final Reflection.FieldAccessor actionField = Reflection.getField(packetPlayInUseEntityClazz, "action", Object.class);
+    private final Reflection.FieldAccessor<Integer> entityIdField = Reflection.getField(packetPlayInUseEntityClazz, "a", int.class);
+    private final Reflection.FieldAccessor<?> actionField = Reflection.getField(packetPlayInUseEntityClazz, "action", Object.class);
 
     // Prevent players from clicking at very high speeds.
     private final Set<UUID> delay = new HashSet<>();
@@ -54,7 +53,7 @@ public class PacketListener {
             return true; // We aren't handling the packet.
 
         NPCBase npc = null;
-        int packetEntityId = (int) entityIdField.get(packet);
+        int packetEntityId = entityIdField.get(packet);
 
         // Not using streams here is an intentional choice.
         // Packet listeners is one of the few places where it is important to write optimized code.
@@ -102,7 +101,7 @@ public class PacketListener {
         public void run() {
             Player player = eventToCall.getWhoClicked();
             this.listener.delay.remove(player.getUniqueId()); // Remove the NPC from the interact cooldown.
-            if (!Objects.equals(player.getWorld(), eventToCall.getNPC().getWorld()))
+            if (!player.getWorld().equals(eventToCall.getNPC().getWorld()))
                 return; // If the NPC and player are not in the same world, abort!
 
             double distance = player.getLocation(playerLocation).distanceSquared(eventToCall.getNPC().getLocation());

--- a/nms/pom.xml
+++ b/nms/pom.xml
@@ -24,6 +24,7 @@
         <module>v1_13_R1</module>
         <module>v1_13_R2</module>
         <module>v1_14_R1</module>
+        <module>v1_15_R1</module>
     </modules>
 
     <dependencies>

--- a/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/NPC_v1_10_R1.java
+++ b/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/NPC_v1_10_R1.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_10_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_10_R1 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_10_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_10_R1 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_10_R1 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_10_R1/src/main/java/net/jitse/npclib/nms/v1_10_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_10_R1.DataWatcherObject;
 import net.minecraft.server.v1_10_R1.DataWatcherRegistry;
 import net.minecraft.server.v1_10_R1.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/NPC_v1_11_R1.java
+++ b/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/NPC_v1_11_R1.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_11_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_11_R1 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_11_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_11_R1 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_11_R1 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_11_R1/src/main/java/net/jitse/npclib/nms/v1_11_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_11_R1.DataWatcherObject;
 import net.minecraft.server.v1_11_R1.DataWatcherRegistry;
 import net.minecraft.server.v1_11_R1.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/NPC_v1_12_R1.java
+++ b/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/NPC_v1_12_R1.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_12_R1 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_12_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_12_R1 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_12_R1 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_12_R1/src/main/java/net/jitse/npclib/nms/v1_12_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_12_R1.DataWatcherObject;
 import net.minecraft.server.v1_12_R1.DataWatcherRegistry;
 import net.minecraft.server.v1_12_R1.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/NPC_v1_13_R1.java
+++ b/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/NPC_v1_13_R1.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_13_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_13_R1 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_13_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_13_R1 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_13_R1 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_13_R1/src/main/java/net/jitse/npclib/nms/v1_13_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_13_R1.DataWatcherObject;
 import net.minecraft.server.v1_13_R1.DataWatcherRegistry;
 import net.minecraft.server.v1_13_R1.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/NPC_v1_13_R2.java
+++ b/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/NPC_v1_13_R2.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_13_R2.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_13_R2 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_13_R2(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_13_R2 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_13_R2 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_13_R2/src/main/java/net/jitse/npclib/nms/v1_13_R2/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_13_R2.DataWatcherObject;
 import net.minecraft.server.v1_13_R2.DataWatcherRegistry;
 import net.minecraft.server.v1_13_R2.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/NPC_v1_14_R1.java
+++ b/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/NPC_v1_14_R1.java
@@ -13,10 +13,7 @@ import org.bukkit.craftbukkit.v1_14_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -28,7 +25,6 @@ public class NPC_v1_14_R1 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_14_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -58,12 +54,6 @@ public class NPC_v1_14_R1 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -104,39 +94,8 @@ public class NPC_v1_14_R1 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_14_R1/src/main/java/net/jitse/npclib/nms/v1_14_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_14_R1.DataWatcherObject;
 import net.minecraft.server.v1_14_R1.DataWatcherRegistry;
 import net.minecraft.server.v1_14_R1.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         // TODO: Find out why NPCState#CROUCHED doesn't work.

--- a/nms/v1_15_R1/pom.xml
+++ b/nms/v1_15_R1/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>net.jitse</groupId>
+        <artifactId>npclib-nms</artifactId>
+        <version>2.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>npclib-nms-v1_15_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
@@ -57,12 +57,6 @@ public class NPC_v1_15_R1 extends NPCBase {
     }
 
     @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
-    }
-
-    @Override
     public void sendShowPackets(Player player) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/NPC_v1_15_R1.java
@@ -1,0 +1,110 @@
+package net.jitse.npclib.nms.v1_15_R1;
+
+import net.jitse.npclib.NPCLib;
+import net.jitse.npclib.api.state.NPCSlot;
+import net.jitse.npclib.hologram.Hologram;
+import net.jitse.npclib.internal.MinecraftVersion;
+import net.jitse.npclib.internal.NPCBase;
+import net.jitse.npclib.nms.v1_15_R1.packets.*;
+import net.minecraft.server.v1_15_R1.*;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_15_R1.inventory.CraftItemStack;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * @author Jitse Boonstra
+ */
+public class NPC_v1_15_R1 extends NPCBase {
+
+    private PacketPlayOutNamedEntitySpawn packetPlayOutNamedEntitySpawn;
+    private PacketPlayOutScoreboardTeam packetPlayOutScoreboardTeamRegister;
+    private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
+    private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
+    private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
+
+    public NPC_v1_15_R1(NPCLib instance, List<String> lines) {
+        super(instance, lines);
+    }
+
+    @Override
+    public void createPackets() {
+        this.hologram = new Hologram(MinecraftVersion.V1_15_R1, location.clone().add(0, 0.5, 0), text);
+
+        PacketPlayOutPlayerInfoWrapper packetPlayOutPlayerInfoWrapper = new PacketPlayOutPlayerInfoWrapper();
+
+        // Packets for spawning the NPC:
+        this.packetPlayOutScoreboardTeamRegister = new PacketPlayOutScoreboardTeamWrapper()
+                .createRegisterTeam(name); // First packet to send.
+
+        this.packetPlayOutPlayerInfoAdd = packetPlayOutPlayerInfoWrapper
+                .create(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, gameProfile, name); // Second packet to send.
+
+        this.packetPlayOutNamedEntitySpawn = new PacketPlayOutNamedEntitySpawnWrapper()
+                .create(uuid, location, entityId); // Third packet to send.
+
+        this.packetPlayOutEntityHeadRotation = new PacketPlayOutEntityHeadRotationWrapper()
+                .create(location, entityId); // Fourth packet to send.
+
+        this.packetPlayOutPlayerInfoRemove = packetPlayOutPlayerInfoWrapper
+                .create(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, gameProfile, name); // Fifth packet to send (delayed).
+
+        // Packet for destroying the NPC:
+        this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
+    }
+
+    @Override
+    public void onLogout(Player player) {
+        super.onLogout(player);
+        hasTeamRegistered.remove(player.getUniqueId());
+    }
+
+    @Override
+    public void sendShowPackets(Player player) {
+        PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
+
+        if (hasTeamRegistered.add(player.getUniqueId()))
+            playerConnection.sendPacket(packetPlayOutScoreboardTeamRegister);
+        playerConnection.sendPacket(packetPlayOutPlayerInfoAdd);
+        playerConnection.sendPacket(packetPlayOutNamedEntitySpawn);
+        playerConnection.sendPacket(packetPlayOutEntityHeadRotation);
+        sendMetadataPacket(player);
+
+        hologram.show(player);
+
+        Bukkit.getScheduler().runTaskLater(instance.getPlugin(), () ->
+                playerConnection.sendPacket(packetPlayOutPlayerInfoRemove), 50);
+    }
+
+    @Override
+    public void sendHidePackets(Player player) {
+        PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
+
+        playerConnection.sendPacket(packetPlayOutEntityDestroy);
+        playerConnection.sendPacket(packetPlayOutPlayerInfoRemove);
+
+        hologram.hide(player);
+    }
+
+    @Override
+    public void sendMetadataPacket(Player player) {
+        PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
+        PacketPlayOutEntityMetadata packet = new PacketPlayOutEntityMetadataWrapper().create(activeStates, entityId);
+
+        playerConnection.sendPacket(packet);
+    }
+
+    @Override
+    public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
+        PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
+
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
+
+        PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
+        playerConnection.sendPacket(packet);
+    }
+}

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutEntityHeadRotationWrapper.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutEntityHeadRotationWrapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Jitse Boonstra
+ */
+
+package net.jitse.npclib.nms.v1_15_R1.packets;
+
+import com.comphenix.tinyprotocol.Reflection;
+import net.minecraft.server.v1_15_R1.PacketPlayOutEntityHeadRotation;
+import org.bukkit.Location;
+
+/**
+ * @author Jitse Boonstra
+ */
+public class PacketPlayOutEntityHeadRotationWrapper {
+
+    public PacketPlayOutEntityHeadRotation create(Location location, int entityId) {
+        PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation = new PacketPlayOutEntityHeadRotation();
+
+        Reflection.getField(packetPlayOutEntityHeadRotation.getClass(), "a", int.class).
+                set(packetPlayOutEntityHeadRotation, entityId);
+        Reflection.getField(packetPlayOutEntityHeadRotation.getClass(), "b", byte.class)
+                .set(packetPlayOutEntityHeadRotation, (byte) ((int) location.getYaw() * 256.0F / 360.0F));
+
+        return packetPlayOutEntityHeadRotation;
+    }
+}

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -1,0 +1,39 @@
+package net.jitse.npclib.nms.v1_15_R1.packets;
+
+import net.jitse.npclib.api.state.NPCState;
+import net.minecraft.server.v1_15_R1.DataWatcher;
+import net.minecraft.server.v1_15_R1.DataWatcherObject;
+import net.minecraft.server.v1_15_R1.DataWatcherRegistry;
+import net.minecraft.server.v1_15_R1.PacketPlayOutEntityMetadata;
+
+import java.util.Collection;
+
+public class PacketPlayOutEntityMetadataWrapper {
+
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
+        DataWatcher dataWatcher = new DataWatcher(null);
+        dataWatcher.register(new DataWatcherObject<>(16, DataWatcherRegistry.a), (byte) 127);
+
+        byte masked = NPCState.getMasked(activateStates);
+        // TODO: Find out why NPCState#CROUCHED doesn't work.
+        dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);
+
+//        for (Player online : Bukkit.getOnlinePlayers()) {
+//            DataWatcher watcher = ((CraftPlayer) online).getHandle().getDataWatcher();
+//            try {
+//                Field entriesField = watcher.getClass().getDeclaredField("entries");
+//                entriesField.setAccessible(true);
+//
+//                Int2ObjectOpenHashMap<DataWatcher.Item<?>> entries = (Int2ObjectOpenHashMap<DataWatcher.Item<?>>) entriesField.get(watcher);
+//                entries.forEach((integer, item) -> {
+//                    if (item.b() instanceof Boolean || item.b() instanceof Byte)
+//                        online.sendMessage(integer + ": " + item.b() + " type = " + item.b().getClass().toString());
+//                });
+//            } catch (NoSuchFieldException | IllegalAccessException e) {
+//                e.printStackTrace();
+//            }
+//        }
+
+        return new PacketPlayOutEntityMetadata(entityId, dataWatcher, true);
+    }
+}

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutNamedEntitySpawnWrapper.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutNamedEntitySpawnWrapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018 Jitse Boonstra
+ */
+
+package net.jitse.npclib.nms.v1_15_R1.packets;
+
+import com.comphenix.tinyprotocol.Reflection;
+import net.minecraft.server.v1_15_R1.PacketPlayOutNamedEntitySpawn;
+import org.bukkit.Location;
+
+import java.util.UUID;
+
+/**
+ * @author Jitse Boonstra
+ */
+public class PacketPlayOutNamedEntitySpawnWrapper {
+
+    public PacketPlayOutNamedEntitySpawn create(UUID uuid, Location location, int entityId) {
+        PacketPlayOutNamedEntitySpawn packetPlayOutNamedEntitySpawn = new PacketPlayOutNamedEntitySpawn();
+
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "a", int.class)
+                .set(packetPlayOutNamedEntitySpawn, entityId);
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "b", UUID.class)
+                .set(packetPlayOutNamedEntitySpawn, uuid);
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "c", double.class)
+                .set(packetPlayOutNamedEntitySpawn, location.getX());
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "d", double.class)
+                .set(packetPlayOutNamedEntitySpawn, location.getY());
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "e", double.class)
+                .set(packetPlayOutNamedEntitySpawn, location.getZ());
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "f", byte.class)
+                .set(packetPlayOutNamedEntitySpawn, (byte) ((int) (location.getYaw() * 256.0F / 360.0F)));
+        Reflection.getField(packetPlayOutNamedEntitySpawn.getClass(), "g", byte.class)
+                .set(packetPlayOutNamedEntitySpawn, (byte) ((int) (location.getPitch() * 256.0F / 360.0F)));
+
+        return packetPlayOutNamedEntitySpawn;
+    }
+}

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutPlayerInfoWrapper.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutPlayerInfoWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 Jitse Boonstra
+ */
+
+package net.jitse.npclib.nms.v1_15_R1.packets;
+
+import com.comphenix.tinyprotocol.Reflection;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.v1_15_R1.EnumGamemode;
+import net.minecraft.server.v1_15_R1.IChatBaseComponent;
+import net.minecraft.server.v1_15_R1.PacketPlayOutPlayerInfo;
+import org.bukkit.ChatColor;
+
+import java.util.List;
+
+/**
+ * @author Jitse Boonstra
+ */
+public class PacketPlayOutPlayerInfoWrapper {
+
+    private final Class<?> packetPlayOutPlayerInfoClazz = Reflection.getMinecraftClass("PacketPlayOutPlayerInfo");
+    private final Class<?> playerInfoDataClazz = Reflection.getMinecraftClass("PacketPlayOutPlayerInfo$PlayerInfoData");
+    private final Reflection.ConstructorInvoker playerInfoDataConstructor = Reflection.getConstructor(playerInfoDataClazz,
+            packetPlayOutPlayerInfoClazz, GameProfile.class, int.class, EnumGamemode.class, IChatBaseComponent.class);
+
+    public PacketPlayOutPlayerInfo create(PacketPlayOutPlayerInfo.EnumPlayerInfoAction action, GameProfile gameProfile, String name) {
+        PacketPlayOutPlayerInfo packetPlayOutPlayerInfo = new PacketPlayOutPlayerInfo();
+        Reflection.getField(packetPlayOutPlayerInfo.getClass(), "a", PacketPlayOutPlayerInfo.EnumPlayerInfoAction.class)
+                .set(packetPlayOutPlayerInfo, action);
+
+        Object playerInfoData = playerInfoDataConstructor.invoke(packetPlayOutPlayerInfo,
+                gameProfile, 1, EnumGamemode.NOT_SET,
+                IChatBaseComponent.ChatSerializer.b("{\"text\":\"" + ChatColor.BLUE + "[NPC] " + name + "\"}")
+        );
+
+        Reflection.FieldAccessor<List> fieldAccessor = Reflection.getField(packetPlayOutPlayerInfo.getClass(), "b", List.class);
+        List list = fieldAccessor.get(packetPlayOutPlayerInfo);
+        list.add(playerInfoData);
+        fieldAccessor.set(packetPlayOutPlayerInfo, list);
+
+        return packetPlayOutPlayerInfo;
+    }
+}

--- a/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutScoreboardTeamWrapper.java
+++ b/nms/v1_15_R1/src/main/java/net/jitse/npclib/nms/v1_15_R1/packets/PacketPlayOutScoreboardTeamWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 Jitse Boonstra
+ */
+
+package net.jitse.npclib.nms.v1_15_R1.packets;
+
+import com.comphenix.tinyprotocol.Reflection;
+import net.minecraft.server.v1_15_R1.ChatComponentText;
+import net.minecraft.server.v1_15_R1.IChatBaseComponent;
+import net.minecraft.server.v1_15_R1.PacketPlayOutScoreboardTeam;
+
+import java.util.Collection;
+
+/**
+ * @author Jitse Boonstra
+ */
+public class PacketPlayOutScoreboardTeamWrapper {
+
+    public PacketPlayOutScoreboardTeam createRegisterTeam(String name) {
+        PacketPlayOutScoreboardTeam packetPlayOutScoreboardTeam = new PacketPlayOutScoreboardTeam();
+
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "i", int.class)
+                .set(packetPlayOutScoreboardTeam, 0);
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "a", String.class)
+                .set(packetPlayOutScoreboardTeam, name);
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "b", IChatBaseComponent.class)
+                .set(packetPlayOutScoreboardTeam, new ChatComponentText(name));
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "e", String.class)
+                .set(packetPlayOutScoreboardTeam, "never");
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "f", String.class)
+                .set(packetPlayOutScoreboardTeam, "never");
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "j", int.class)
+                .set(packetPlayOutScoreboardTeam, 0);
+        Reflection.FieldAccessor<Collection> collectionFieldAccessor = Reflection.getField(
+                packetPlayOutScoreboardTeam.getClass(), "h", Collection.class);
+        Collection collection = collectionFieldAccessor.get(packetPlayOutScoreboardTeam);
+        collection.add(name);
+        collectionFieldAccessor.set(packetPlayOutScoreboardTeam, collection);
+
+        return packetPlayOutScoreboardTeam;
+    }
+
+    public PacketPlayOutScoreboardTeam createUnregisterTeam(String name) {
+        PacketPlayOutScoreboardTeam packetPlayOutScoreboardTeam = new PacketPlayOutScoreboardTeam();
+
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "i", int.class)
+                .set(packetPlayOutScoreboardTeam, 1);
+        Reflection.getField(packetPlayOutScoreboardTeam.getClass(), "a", String.class)
+                .set(packetPlayOutScoreboardTeam, name);
+
+        return packetPlayOutScoreboardTeam;
+    }
+}

--- a/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/NPC_v1_8_R2.java
+++ b/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/NPC_v1_8_R2.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_8_R2.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_8_R2 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_8_R2(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_8_R2 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -107,29 +97,11 @@ public class NPC_v1_8_R2 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                break;
-            case BOOTS:
-                item = boots;
-                break;
-            case MAINHAND:
-                item = inHand;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
+        if (slot == NPCSlot.OFFHAND && !auto) {
+            throw new UnsupportedOperationException("Offhand is not supported on servers below 1.9");
         }
+
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, slot.getSlot(), CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_8_R2/src/main/java/net/jitse/npclib/nms/v1_8_R2/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -4,9 +4,11 @@ import net.jitse.npclib.api.state.NPCState;
 import net.minecraft.server.v1_8_R2.DataWatcher;
 import net.minecraft.server.v1_8_R2.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.a(0, masked);

--- a/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/NPC_v1_8_R3.java
+++ b/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/NPC_v1_8_R3.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_8_R3.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_8_R3 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_8_R3(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_8_R3 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,29 +98,11 @@ public class NPC_v1_8_R3 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                break;
-            case BOOTS:
-                item = boots;
-                break;
-            case MAINHAND:
-                item = inHand;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
+        if (slot == NPCSlot.OFFHAND && !auto) {
+            throw new UnsupportedOperationException("Offhand is not supported on servers below 1.9");
         }
+
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, slot.getSlot(), CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_8_R3/src/main/java/net/jitse/npclib/nms/v1_8_R3/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -4,9 +4,11 @@ import net.jitse.npclib.api.state.NPCState;
 import net.minecraft.server.v1_8_R3.DataWatcher;
 import net.minecraft.server.v1_8_R3.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.a(0, masked);

--- a/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/NPC_v1_9_R1.java
+++ b/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/NPC_v1_9_R1.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_9_R1.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_9_R1 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_9_R1(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_9_R1 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_9_R1 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_9_R1/src/main/java/net/jitse/npclib/nms/v1_9_R1/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_9_R1.DataWatcherObject;
 import net.minecraft.server.v1_9_R1.DataWatcherRegistry;
 import net.minecraft.server.v1_9_R1.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/NPC_v1_9_R2.java
+++ b/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/NPC_v1_9_R2.java
@@ -17,10 +17,7 @@ import org.bukkit.craftbukkit.v1_9_R2.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 /**
  * @author Jitse Boonstra
@@ -32,7 +29,6 @@ public class NPC_v1_9_R2 extends NPCBase {
     private PacketPlayOutPlayerInfo packetPlayOutPlayerInfoAdd, packetPlayOutPlayerInfoRemove;
     private PacketPlayOutEntityHeadRotation packetPlayOutEntityHeadRotation;
     private PacketPlayOutEntityDestroy packetPlayOutEntityDestroy;
-    private Set<UUID> hasTeamRegistered = new HashSet<>();
 
     public NPC_v1_9_R2(NPCLib instance, List<String> lines) {
         super(instance, lines);
@@ -62,12 +58,6 @@ public class NPC_v1_9_R2 extends NPCBase {
 
         // Packet for destroying the NPC:
         this.packetPlayOutEntityDestroy = new PacketPlayOutEntityDestroy(entityId); // First packet to send.
-    }
-
-    @Override
-    public void onLogout(Player player) {
-        super.onLogout(player);
-        hasTeamRegistered.remove(player.getUniqueId());
     }
 
     @Override
@@ -108,39 +98,8 @@ public class NPC_v1_9_R2 extends NPCBase {
     public void sendEquipmentPacket(Player player, NPCSlot slot, boolean auto) {
         PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().playerConnection;
 
-        EnumItemSlot nmsSlot;
-        ItemStack item;
-        switch (slot) {
-            case HELMET:
-                item = helmet;
-                nmsSlot = EnumItemSlot.HEAD;
-                break;
-            case CHESTPLATE:
-                item = chestplate;
-                nmsSlot = EnumItemSlot.CHEST;
-                break;
-            case LEGGINGS:
-                item = leggings;
-                nmsSlot = EnumItemSlot.LEGS;
-                break;
-            case BOOTS:
-                item = boots;
-                nmsSlot = EnumItemSlot.FEET;
-                break;
-            case MAINHAND:
-                item = inHand;
-                nmsSlot = EnumItemSlot.MAINHAND;
-                break;
-            case OFFHAND:
-                item = offHand;
-                nmsSlot = EnumItemSlot.OFFHAND;
-                break;
-            default:
-                if (!auto) {
-                    throw new IllegalArgumentException(slot.toString() + " is not a supported slot for the version of your server");
-                }
-                return;
-        }
+        EnumItemSlot nmsSlot = slot.getNmsEnum(EnumItemSlot.class);
+        ItemStack item = getItem(slot);
 
         PacketPlayOutEntityEquipment packet = new PacketPlayOutEntityEquipment(entityId, nmsSlot, CraftItemStack.asNMSCopy(item));
         playerConnection.sendPacket(packet);

--- a/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/packets/PacketPlayOutEntityMetadataWrapper.java
+++ b/nms/v1_9_R2/src/main/java/net/jitse/npclib/nms/v1_9_R2/packets/PacketPlayOutEntityMetadataWrapper.java
@@ -6,9 +6,11 @@ import net.minecraft.server.v1_9_R2.DataWatcherObject;
 import net.minecraft.server.v1_9_R2.DataWatcherRegistry;
 import net.minecraft.server.v1_9_R2.PacketPlayOutEntityMetadata;
 
+import java.util.Collection;
+
 public class PacketPlayOutEntityMetadataWrapper {
 
-    public PacketPlayOutEntityMetadata create(NPCState[] activateStates, int entityId) {
+    public PacketPlayOutEntityMetadata create(Collection<NPCState> activateStates, int entityId) {
         DataWatcher dataWatcher = new DataWatcher(null);
         byte masked = NPCState.getMasked(activateStates);
         dataWatcher.register(new DataWatcherObject<>(0, DataWatcherRegistry.a), masked);

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -86,6 +86,12 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jitse</groupId>
+            <artifactId>npclib-nms-v1_15_R1</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Add 1.15 support and cleanup some code:

* Add 1.15.* support
* Simplify code of `NPCBase#getItem`, `NPCBase#setItem`, `NPCBase#toggleState`
* Remove duplicated code in `NPC_v1_*R*#sendEquipmentPacket` and `NPC_v1_*R*#onLogout`
* Fix NPE spam in ChunkListener when a NPC don't have a location
* Fix compiler warn with rawtypes
* Add missing imports in MineSkinFetcher
* Log the full stacktrace when an error occurs while creating an NPC or with TinyProtocol (it's a lot harder to find the problem with only the message)

I tested the changes quickly, but it should be better to test again to be sure there is no problems :)